### PR TITLE
Fix equality check for Number

### DIFF
--- a/NS12.VariableBase.Mathematics.Providers.Tests/CharMathEnvironment_additional_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/CharMathEnvironment_additional_tests.cs
@@ -1,0 +1,142 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class CharMathEnvironment_Additional_Tests
+    {
+        [TestMethod]
+        public void Environment_Equals_SameKey_Test()
+        {
+            IMathEnvironment<Number> env1 = new CharMathEnvironment("0123456789");
+            IMathEnvironment<Number> env2 = new CharMathEnvironment("0123456789");
+
+            Assert.IsTrue(env1.Equals(env2));
+            Assert.IsTrue(env2.Equals(env1));
+        }
+
+        [TestMethod]
+        public void Environment_Definition_RoundTrip_Test()
+        {
+            IMathEnvironment<Number> env1 = new CharMathEnvironment("abcde");
+            string def = env1.GetDefinition();
+            IMathEnvironment<Number> env2 = new CharMathEnvironment(def);
+
+            Assert.IsTrue(env1.Equals(env2));
+        }
+
+        [TestMethod]
+        public void Parse_Convert_RoundTrip_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            string raw = "1234567890";
+            var segments = env.ParseNumberSegments(raw);
+            string converted = env.ConvertToString(segments);
+            Assert.AreEqual(raw, converted);
+        }
+
+        [TestMethod]
+        public void GetNumber_Decimal_RoundTrip_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number number = env.GetNumber(987654321m);
+            Assert.AreEqual("987654321", number.ToString());
+        }
+
+        [TestMethod]
+        public void IsZero_EmptyString_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.IsZero(""));
+        }
+
+        [TestMethod]
+        public void IsZero_AllZeros_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.IsZero("0000"));
+        }
+
+        [TestMethod]
+        public void IsZero_NotZero_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsFalse(env.IsZero("010"));
+        }
+
+        [TestMethod]
+        public void IsOne_SingleOne_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.IsOne("1"));
+        }
+
+        [TestMethod]
+        public void IsOne_WithLeadingZeros_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.IsOne("0001"));
+        }
+
+        [TestMethod]
+        public void IsOne_False_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsFalse(env.IsOne("11"));
+        }
+
+        [TestMethod]
+        public void Add_Binary_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Number a = env.GetNumber("101");
+            Number b = env.GetNumber("1");
+            Number result = a + b;
+            Assert.AreEqual("110", result.ToString());
+        }
+
+        [TestMethod]
+        public void Multiply_Decimal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number seven = env.GetNumber("7");
+            Number six = env.GetNumber("6");
+            Number result = seven * six;
+            Assert.AreEqual("42", result.ToString());
+        }
+
+        [TestMethod]
+        public void Divide_Decimal_WithRemainder_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number seven = env.GetNumber("7");
+            Number two = env.GetNumber("2");
+            Number result = seven / two;
+            Assert.AreEqual("3 1/2", result.ToString());
+        }
+
+        [TestMethod]
+        public void Modulo_Decimal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number a = env.GetNumber("7");
+            Number b = env.GetNumber("5");
+            Number result = a % b;
+            Assert.AreEqual("2", result.ToString());
+        }
+
+        [TestMethod]
+        public void Number_Comparison_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number two = env.GetNumber("2");
+            Number three = env.GetNumber("3");
+            Assert.IsTrue(two < three);
+            Assert.IsTrue(three > two);
+            Assert.IsTrue(three >= three);
+            Assert.IsTrue(two <= two);
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_binary_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_binary_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Binary_Tests
+    {
+        [TestMethod]
+        public void Binary_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Binary_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Binary_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Binary_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Binary_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Binary_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Binary_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_decimal_basic_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_decimal_basic_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Decimal_Basic_Tests
+    {
+        [TestMethod]
+        public void Decimal_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Decimal_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Decimal_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Decimal_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Decimal_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Decimal_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Decimal_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_decimal_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_decimal_tests.cs
@@ -74,5 +74,15 @@ namespace NS12.VariableBase.Mathematics.Providers.Tests
             Assert.AreEqual(result, mathEnvironment.GetNumber("6", null, null, true));
         }
 
+        [TestMethod]
+        public void Environment_Equals_KeyMismatch_Test()
+        {
+            IMathEnvironment<Number> env1 = new CharMathEnvironment("0123");
+            IMathEnvironment<Number> env2 = new CharMathEnvironment("0124");
+
+            Assert.IsFalse(env1.Equals(env2));
+            Assert.IsFalse(env2.Equals(env1));
+        }
+
     }
 }

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_equals_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_equals_tests.cs
@@ -1,0 +1,34 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Equals_Tests
+    {
+        [TestMethod]
+        public void Equals_Number_Null_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number one = env.GetNumber(1m);
+            Assert.IsFalse(one.Equals((Number)null));
+        }
+
+        [TestMethod]
+        public void Equals_Object_Null_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number one = env.GetNumber(1m);
+            Assert.IsFalse(one.Equals((object?)null));
+        }
+
+        [TestMethod]
+        public void Equals_Object_InvalidType_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789");
+            Number one = env.GetNumber(1m);
+            Assert.IsFalse(one.Equals("1"));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_hexadecimal_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_hexadecimal_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Hexadecimal_Tests
+    {
+        [TestMethod]
+        public void Hexadecimal_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Hexadecimal_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Hexadecimal_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Hexadecimal_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Hexadecimal_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Hexadecimal_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Hexadecimal_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEF");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_hexatridecimal_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_hexatridecimal_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Hexatridecimal_Tests
+    {
+        [TestMethod]
+        public void Hexatridecimal_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Hexatridecimal_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_large_value_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_large_value_tests.cs
@@ -1,0 +1,77 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+using System.Collections.Generic;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Large_Value_Tests
+    {
+        public static IEnumerable<object[]> Environments()
+        {
+            yield return new object[] { new CharMathEnvironment("01") };
+            yield return new object[] { new CharMathEnvironment("012") };
+            yield return new object[] { new CharMathEnvironment("01234") };
+            yield return new object[] { new CharMathEnvironment("012345") };
+            yield return new object[] { new CharMathEnvironment("01234567") };
+            yield return new object[] { new CharMathEnvironment("0123456789") };
+            yield return new object[] { new CharMathEnvironment("0123456789ABCDEF") };
+            yield return new object[] { new CharMathEnvironment("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") };
+            yield return new object[] { new CharMathEnvironment((char)63404) };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_Add_Test(IMathEnvironment<Number> env)
+        {
+            Number result = env.GetNumber(123456789012345678m) + env.GetNumber(987654321098765432m);
+            Assert.AreEqual(env.GetNumber(1111111110111111110m), result);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_Subtract_Test(IMathEnvironment<Number> env)
+        {
+            Number result = env.GetNumber(5000000000000000000m) - env.GetNumber(3000000000000000000m);
+            Assert.AreEqual(env.GetNumber(2000000000000000000m), result);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_Multiply_Test(IMathEnvironment<Number> env)
+        {
+            Number result = env.GetNumber(12345678m) * env.GetNumber(98765432m);
+            Assert.AreEqual(env.GetNumber(1219326221002896m), result);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_Divide_Test(IMathEnvironment<Number> env)
+        {
+            Number result = env.GetNumber(999999999999999999m) / env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(333333333333333333m), result);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_GreaterThan_Test(IMathEnvironment<Number> env)
+        {
+            Assert.IsTrue(env.GetNumber(2000000000000000000m) > env.GetNumber(1000000000000000000m));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_LessThan_Test(IMathEnvironment<Number> env)
+        {
+            Assert.IsTrue(env.GetNumber(1000000000000000000m) < env.GetNumber(2000000000000000000m));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Environments), DynamicDataSourceType.Method)]
+        public void Large_Equal_Test(IMathEnvironment<Number> env)
+        {
+            Assert.IsTrue(env.GetNumber(4000000000000000000m) == env.GetNumber(4000000000000000000m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_octal_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_octal_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Octal_Tests
+    {
+        [TestMethod]
+        public void Octal_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Octal_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Octal_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Octal_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Octal_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Octal_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Octal_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234567");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_quinary_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_quinary_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Quinary_Tests
+    {
+        [TestMethod]
+        public void Quinary_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Quinary_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Quinary_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Quinary_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Quinary_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Quinary_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Quinary_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("01234");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_radix63404_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_radix63404_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Radix63404_Tests
+    {
+        [TestMethod]
+        public void Radix63404_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Radix63404_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Radix63404_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Radix63404_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Radix63404_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Radix63404_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Radix63404_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment((char)63404);
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_senary_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_senary_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Senary_Tests
+    {
+        [TestMethod]
+        public void Senary_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Senary_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Senary_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Senary_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Senary_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Senary_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Senary_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012345");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers.Tests/Number_ternary_tests.cs
+++ b/NS12.VariableBase.Mathematics.Providers.Tests/Number_ternary_tests.cs
@@ -1,0 +1,63 @@
+using NS12.VariableBase.Mathematics.Common.Interfaces;
+using NS12.VariableBase.Mathematics.Common.Models;
+using NS12.VariableBase.Mathematics.Providers.MathEnvironments;
+
+namespace NS12.VariableBase.Mathematics.Providers.Tests
+{
+    [TestClass]
+    public class Number_Ternary_Tests
+    {
+        [TestMethod]
+        public void Ternary_Add_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Number result = env.GetNumber(2m) + env.GetNumber(1m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Ternary_Subtract_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Number result = env.GetNumber(5m) - env.GetNumber(3m);
+            Assert.AreEqual(env.GetNumber(2m), result);
+        }
+
+        [TestMethod]
+        public void Ternary_Multiply_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Number result = env.GetNumber(3m) * env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(6m), result);
+        }
+
+        [TestMethod]
+        public void Ternary_Divide_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Number result = env.GetNumber(6m) / env.GetNumber(2m);
+            Assert.AreEqual(env.GetNumber(3m), result);
+        }
+
+        [TestMethod]
+        public void Ternary_GreaterThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Assert.IsTrue(env.GetNumber(3m) > env.GetNumber(2m));
+        }
+
+        [TestMethod]
+        public void Ternary_LessThan_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Assert.IsTrue(env.GetNumber(2m) < env.GetNumber(3m));
+        }
+
+        [TestMethod]
+        public void Ternary_Equal_Test()
+        {
+            IMathEnvironment<Number> env = new CharMathEnvironment("012");
+            Assert.IsTrue(env.GetNumber(4m) == env.GetNumber(4m));
+        }
+    }
+}

--- a/NS12.VariableBase.Mathematics.Providers/MathEnvironments/CharMathEnvironment.cs
+++ b/NS12.VariableBase.Mathematics.Providers/MathEnvironments/CharMathEnvironment.cs
@@ -332,7 +332,7 @@ namespace NS12.VariableBase.Mathematics.Providers.MathEnvironments
 
         public bool Equals(IMathEnvironment<Number> other)
         {
-            if (ReferenceEquals(other, default(IMathEnvironment<Number>)) || Base != other.Base)
+            if (ReferenceEquals(other, null))
             {
                 return false;
             }
@@ -342,10 +342,19 @@ namespace NS12.VariableBase.Mathematics.Providers.MathEnvironments
                 return false;
             }
 
-            if (Base != other.Base)
+            if (Key.Count != other.Key.Count)
             {
                 return false;
             }
+
+            for (int i = 0; i < Key.Count; i++)
+            {
+                if (Key[i] != other.Key[i])
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
 

--- a/NS12.VariableBase.Mathematics.Providers/Number.cs
+++ b/NS12.VariableBase.Mathematics.Providers/Number.cs
@@ -357,11 +357,15 @@ namespace NS12.VariableBase.Mathematics.Providers
 
         public override bool Equals(object other)
         {
-            return Operator.Compare(this, (Number)other) == 0;
+            return other is Number number && Operator.Compare(this, number) == 0;
         }
 
         public bool Equals(Number other)
         {
+            if (other is null)
+            {
+                return false;
+            }
             return Operator.Compare(this, other) == 0;
         }
 


### PR DESCRIPTION
## Summary
- handle invalid arguments in `Number.Equals`
- test equality handling for null and mismatched types

## Testing
- `dotnet test NS12.VariableBase.Mathematics.Providers.Tests/NS12.VariableBase.Mathematics.Providers.Tests.csproj --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687653b92bc8832f8a341b8016fc74ff